### PR TITLE
Add syndication request support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ app.use('/micropub', micropub({
     me: 'http://example.com/',
     endpoint: 'https://tokens.indieauth.com/token',
   },
+  
+  // Specify available syndication handlers
+  syndication: ['https://twitter.com/example', 'https://facebook.com/example'],
 
   // And lastly: Do something with the created micropub document
   handler: function (micropubDocument, req) {


### PR DESCRIPTION
Gives the ability to return available syndication options when requesting `?q=syndicate-to`.

Not much of a node programmer so there's likely a nicer way to do this but it works for me.

Currently missing tests.